### PR TITLE
[Refactor] DBHelper 싱글톤 패턴 적용 및 getInstance() 방식으로 변경

### DIFF
--- a/app/src/main/java/smu/team3_orda_diary/MainActivity.java
+++ b/app/src/main/java/smu/team3_orda_diary/MainActivity.java
@@ -15,13 +15,11 @@ import androidx.navigation.ui.NavigationUI;
 import java.util.ArrayList;
 import java.util.List;
 
-import smu.team3_orda_diary.database.DBHelper;
 import smu.team3_orda_diary.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity {
     private ActivityMainBinding binding;
     private NavController navController;
-    public static DBHelper mDBHelper;
     private static final int PERMISSION_REQUEST_CODE = 101;
 
     @Override
@@ -30,8 +28,6 @@ public class MainActivity extends AppCompatActivity {
 
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-
-        mDBHelper = new DBHelper(this);
         requestAppPermissions();
 
         NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()

--- a/app/src/main/java/smu/team3_orda_diary/database/DBHelper.java
+++ b/app/src/main/java/smu/team3_orda_diary/database/DBHelper.java
@@ -7,8 +7,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
-import androidx.annotation.Nullable;
-
 import java.util.ArrayList;
 
 import smu.team3_orda_diary.model.OnePageDiary;
@@ -18,8 +16,19 @@ public class DBHelper extends SQLiteOpenHelper {
     public static final int DB_VERSION = 1;
     public static final String DB_NAME = "Ordatest5.db";
 
-    public DBHelper(@Nullable Context context) {
-        super(context, DB_NAME, null, DB_VERSION);
+    private static volatile DBHelper instance;
+
+    private DBHelper(Context context) {
+        super(context.getApplicationContext(), DB_NAME, null, DB_VERSION);
+    }
+
+    public static DBHelper getInstance(Context context) {
+        if (instance == null) {
+            synchronized (DBHelper.class) {
+                if (instance == null) instance = new DBHelper(context);
+            }
+        }
+        return instance;
     }
 
     @Override

--- a/app/src/main/java/smu/team3_orda_diary/ui/alarm/AlarmFragment.java
+++ b/app/src/main/java/smu/team3_orda_diary/ui/alarm/AlarmFragment.java
@@ -1,7 +1,6 @@
 package smu.team3_orda_diary.ui.alarm;
 
 import static android.app.PendingIntent.FLAG_IMMUTABLE;
-import static smu.team3_orda_diary.MainActivity.mDBHelper;
 
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -31,9 +30,11 @@ import java.util.Calendar;
 import java.util.Date;
 
 import smu.team3_orda_diary.R;
+import smu.team3_orda_diary.database.DBHelper;
 import smu.team3_orda_diary.databinding.FragmentAlarmBinding;
 
 public class AlarmFragment extends Fragment {
+    private DBHelper mDBHelper;
     private FragmentAlarmBinding binding;
     private AlarmManager alarmManager;
     private static CameraManager mCameraManager;
@@ -41,6 +42,12 @@ public class AlarmFragment extends Fragment {
     public static String mCameraId;
     private Calendar alarmC;
     private String alarmTime;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mDBHelper = DBHelper.getInstance(requireContext());
+    }
 
     @Nullable
     @Override

--- a/app/src/main/java/smu/team3_orda_diary/ui/diary/DiaryListFragment.java
+++ b/app/src/main/java/smu/team3_orda_diary/ui/diary/DiaryListFragment.java
@@ -14,16 +14,22 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 import java.util.ArrayList;
 
-import smu.team3_orda_diary.MainActivity;
 import smu.team3_orda_diary.R;
+import smu.team3_orda_diary.database.DBHelper;
 import smu.team3_orda_diary.databinding.FragmentDiaryListBinding;
 import smu.team3_orda_diary.model.OnePageDiary;
 
 public class DiaryListFragment extends Fragment {
-
     private FragmentDiaryListBinding binding;
     public static DiaryRecyclerViewAdapter adapter;
     public static ArrayList<OnePageDiary> diaryList;
+    private DBHelper mDBHelper;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mDBHelper = DBHelper.getInstance(requireContext());
+    }
 
     @Nullable
     @Override
@@ -37,7 +43,7 @@ public class DiaryListFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         try {
-            diaryList = MainActivity.mDBHelper.getDiaryList();
+            diaryList = mDBHelper.getDiaryList();
             if (diaryList == null) {
                 diaryList = new ArrayList<>();
             }

--- a/app/src/main/java/smu/team3_orda_diary/ui/diary/DiaryWritingFragment.java
+++ b/app/src/main/java/smu/team3_orda_diary/ui/diary/DiaryWritingFragment.java
@@ -1,7 +1,5 @@
 package smu.team3_orda_diary.ui.diary;
 
-import static smu.team3_orda_diary.MainActivity.mDBHelper;
-
 import android.Manifest;
 import android.app.AlertDialog;
 import android.app.DatePickerDialog;
@@ -43,11 +41,12 @@ import java.util.Calendar;
 import java.util.Date;
 
 import smu.team3_orda_diary.R;
+import smu.team3_orda_diary.database.DBHelper;
 import smu.team3_orda_diary.databinding.FragmentDiaryWritingBinding;
 
 
 public class DiaryWritingFragment extends Fragment {
-
+    private DBHelper mDBHelper;
     private FragmentDiaryWritingBinding binding;
     private DiaryWritingViewModel diaryViewModel;
     private Calendar diaryCalendar;
@@ -56,6 +55,12 @@ public class DiaryWritingFragment extends Fragment {
     private Intent recordIntent;
     private boolean recording = false;
     private String[] feelings;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mDBHelper = DBHelper.getInstance(requireContext());
+    }
 
     @Nullable
     @Override

--- a/app/src/main/java/smu/team3_orda_diary/ui/todolist/ToDoListFragment.java
+++ b/app/src/main/java/smu/team3_orda_diary/ui/todolist/ToDoListFragment.java
@@ -38,6 +38,11 @@ public class ToDoListFragment extends Fragment {
     private static final String CURRENT_TIME_FORMAT = "%d-%02d-%02d";
     private static final String TODO_TODAY_FORMAT = "%d년 %d월 %d일";
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        dbHelper = DBHelper.getInstance(requireContext());
+    }
 
     @Nullable
     @Override
@@ -50,7 +55,6 @@ public class ToDoListFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        dbHelper = new DBHelper(requireContext());
         todoItems = new ArrayList<>();
         todoAdapter = new TodoCustomAdapter(todoItems, requireContext());
 

--- a/app/src/main/java/smu/team3_orda_diary/ui/todolist/TodoCustomAdapter.java
+++ b/app/src/main/java/smu/team3_orda_diary/ui/todolist/TodoCustomAdapter.java
@@ -23,7 +23,7 @@ import smu.team3_orda_diary.model.TodoItem;
 
 public class TodoCustomAdapter extends RecyclerView.Adapter<TodoCustomAdapter.ViewHolder> {
     private final Context mContext;
-    private final DBHelper mDBHelper;
+    private DBHelper mDBHelper;
     private final ArrayList<TodoItem> mTodoItems;
 
     private static final String DATE_PATTERN_DB = "yyyy-MM-dd";
@@ -31,7 +31,7 @@ public class TodoCustomAdapter extends RecyclerView.Adapter<TodoCustomAdapter.Vi
     public TodoCustomAdapter(ArrayList<TodoItem> todoItems, Context context) {
         this.mTodoItems = todoItems;
         this.mContext = context;
-        mDBHelper = new DBHelper(context);
+        mDBHelper = DBHelper.getInstance(context);
     }
 
     @NonNull


### PR DESCRIPTION
# 🔥 리팩토링 개요
DBHelper가 MainActivity에서 static으로 관리되던 구조를 개선하고, 싱글톤 패턴(Singleton Pattern)을 적용하여 전역적으로 하나의 인스턴스만 유지하도록 수정했습니다.

# 🚨 기존 코드의 문제점

1. MainActivity 의존성
- 모든 Fragment와 ViewModel에서 MainActivity.mDBHelper를 import해야 하는 강한 결합(High Coupling) 발생
- MainActivity가 없으면 DBHelper를 사용할 수 없는 구조
![image](https://github.com/user-attachments/assets/f0c51e7e-3360-4347-8ba5-e339c8e9b379)

2. DBHelper 인스턴스가 여러 개 생성될 가능성
- ViewModel에서 DBHelper를 생성할 경우 중복된 인스턴스가 생성될 가능성이 있음
- 동일한 SQLite 데이터베이스에 여러 개의 DBHelper 인스턴스가 접근하는 문제가 발생할 수 있음
- 중복 생성된 인스턴스 확인됨.
![image](https://github.com/user-attachments/assets/ef91db53-17d4-4bce-8599-c2f69a63e252)

3. 테스트 코드 작성 어려움
- DBHelper가 MainActivity에 종속되어 있어서, 테스트 코드에서 독립적으로 사용하기 어려운 구조

# 🛠 변경 사항 (Changes)
✅ DBHelper를 싱글톤 패턴으로 변경
✅ 더블 체크 락킹(Double-Checked Locking) 적용
✅ Fragment, ViewModel에서 DBHelper 가져오는 방식 수정
![image](https://github.com/user-attachments/assets/3d279d13-307f-4ddd-bd58-543bd35d6c1e)

